### PR TITLE
feat: ヘッダーにアカウントDropdownMenuを追加しAuthProviderをApp.tsxに移動

### DIFF
--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -45,8 +45,9 @@ inclusion: always
 - App Shell パターン（Header + Sidebar によるナビゲーション）。サイドバー開閉時は
   `react-remove-scroll-bar`
   でスクロールバーを非表示にし、ヘッダーの padding-right で幅のズレを補正。Sidebar の "Groups" ボタンは
-  `/`、"Users" ボタンは `/users` へ遷移する（`onNavigate(path)` prop 経由）。Header 右端の
-  アカウントボタン（`FaCircleUser` アイコン）は `DropdownMenu` でログインユーザーの UUID・氏名を表示する
+  `/`、"Users" ボタンは `/users` へ遷移する（`onNavigate(path)`
+  prop 経由）。Header 右端のアカウントボタン（`FaCircleUser` アイコン）は `DropdownMenu`
+  でログインユーザーの UUID・氏名を表示する
 - 認証ガード（`ProtectedRoute`）: `GET /api/v1/me` を呼び出してセッション確認。401 は
   `reason="unauthenticated"` で `/service-unavailable` へリダイレクト、その他のエラーは
   `reason="api_unavailable"` でリダイレクト。認証済みユーザー情報（`id`, `uuid`, `firstName`,

--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -45,7 +45,8 @@ inclusion: always
 - App Shell パターン（Header + Sidebar によるナビゲーション）。サイドバー開閉時は
   `react-remove-scroll-bar`
   でスクロールバーを非表示にし、ヘッダーの padding-right で幅のズレを補正。Sidebar の "Groups" ボタンは
-  `/`、"Users" ボタンは `/users` へ遷移する（`onNavigate(path)` prop 経由）
+  `/`、"Users" ボタンは `/users` へ遷移する（`onNavigate(path)` prop 経由）。Header 右端の
+  アカウントボタン（`FaCircleUser` アイコン）は `DropdownMenu` でログインユーザーの UUID・氏名を表示する
 - 認証ガード（`ProtectedRoute`）: `GET /api/v1/me` を呼び出してセッション確認。401 は
   `reason="unauthenticated"` で `/service-unavailable` へリダイレクト、その他のエラーは
   `reason="api_unavailable"` でリダイレクト。認証済みユーザー情報（`id`, `uuid`, `firstName`,

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -30,14 +30,15 @@ src/
 - `index.tsx` — React DOM のマウント（`StrictMode` + `createRoot` + `render`）。Radix UI
   `Theme`（`appearance="light"`, `accentColor="gray"`, `grayColor="slate"`,
   `radius="large"`）でアプリ全体をラップ。HMR 対応（`import.meta.hot` による root の再利用）
-- `App.tsx` — ルートコンポーネント。App Shell パターン（`Header` + `Sidebar` +
-  `RouterProvider`）で構成。Sidebar 開閉時に
+- `App.tsx` — ルートコンポーネント。`AuthProvider` で全体をラップし、その内側に App Shell パターン
+  （`Header` + `Sidebar` + `RouterProvider`）を配置。`AuthProvider` を `RouterProvider` より外側に
+  配置することで、`Header` ウィジェットが `useAuth()` でユーザー情報を参照できる。Sidebar 開閉時に
   `RemoveScrollBar`（`react-remove-scroll-bar`）でスクロールバーを非表示化
 - `router.tsx` — `createBrowserRouter` によるルート定義。最上位の `Layout` コンポーネントが
-  `AuthProvider` と `SheetStackProvider` でアプリ全体をラップ。`/service-unavailable`
-  は認証ガード外に配置。認証が必要なルートは `ProtectedRoute` でラップされ、その内側で
-  `GroupNavigationLayout` が `/`・`/groups`・`/groups/:id`・`/users` のルーティングを制御し、
-  `/users/:id` は `UserDetailPage` を直接レンダリングする。各ルートの `element`
+  `SheetStackProvider` でアプリ全体をラップ（`AuthProvider` は `App.tsx` 側に移動済み）。
+  `/service-unavailable` は認証ガード外に配置。認証が必要なルートは `ProtectedRoute` でラップされ、
+  その内側で `GroupNavigationLayout` が `/`・`/groups`・`/groups/:id`・`/users` のルーティングを
+  制御し、`/users/:id` は `UserDetailPage` を直接レンダリングする。各ルートの `element`
   は空フラグメント（実際の描画は Layout コンポーネントが担う）
 - `routes/ProtectedRoute.tsx` — 認証ガードコンポーネント。`GET /api/v1/me`
   でセッション確認し、認証済みなら子をレンダリング。未認証・API 障害時は `location.state.reason`
@@ -88,7 +89,10 @@ FSD の entities レイヤー。現時点では使用していない（ディレ
 FSD の widgets レイヤー。ページ横断で使われる独立した UI ブロックを配置する。
 
 - `header/` — アプリヘッダー（ハンバーガーメニューボタン付き、`z-index: 150`
-  で Sheet オーバーレイより上に固定）。`ui/Header.tsx`、`ui/Header.styles.ts`、テスト
+  で Sheet オーバーレイより上に固定）。`ui/Header.tsx`、`ui/Header.styles.ts`、テスト。
+  `useAuth()` でログインユーザー情報を取得し、右端の `FaCircleUser` アイコンボタン（`aria-label="Account"`）
+  を押すと Radix UI `DropdownMenu` が開いてユーザーの UUID・氏名を表示する。
+  レイアウトは `gridTemplateColumns: "40px 1fr 40px"` の 3 カラム構成（leading / title / trailing）
 - `sidebar/`
   — サイドバーナビゲーション（オーバーレイ付きドロワー）。`ui/Sidebar.tsx`、`ui/Sidebar.styles.ts`、テスト。Props:
   `isOpen`・`onClose`（必須）、`onNavigate`（任意）。"Groups" ボタンをクリックすると `onClose()` と

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -30,16 +30,17 @@ src/
 - `index.tsx` — React DOM のマウント（`StrictMode` + `createRoot` + `render`）。Radix UI
   `Theme`（`appearance="light"`, `accentColor="gray"`, `grayColor="slate"`,
   `radius="large"`）でアプリ全体をラップ。HMR 対応（`import.meta.hot` による root の再利用）
-- `App.tsx` — ルートコンポーネント。`AuthProvider` で全体をラップし、その内側に App Shell パターン
-  （`Header` + `Sidebar` + `RouterProvider`）を配置。`AuthProvider` を `RouterProvider` より外側に
-  配置することで、`Header` ウィジェットが `useAuth()` でユーザー情報を参照できる。Sidebar 開閉時に
+- `App.tsx` — ルートコンポーネント。`AuthProvider` で全体をラップし、その内側に App
+  Shell パターン（`Header` + `Sidebar` + `RouterProvider`）を配置。`AuthProvider` を
+  `RouterProvider` より外側に配置することで、`Header` ウィジェットが `useAuth()`
+  でユーザー情報を参照できる。Sidebar 開閉時に
   `RemoveScrollBar`（`react-remove-scroll-bar`）でスクロールバーを非表示化
 - `router.tsx` — `createBrowserRouter` によるルート定義。最上位の `Layout` コンポーネントが
   `SheetStackProvider` でアプリ全体をラップ（`AuthProvider` は `App.tsx` 側に移動済み）。
-  `/service-unavailable` は認証ガード外に配置。認証が必要なルートは `ProtectedRoute` でラップされ、
-  その内側で `GroupNavigationLayout` が `/`・`/groups`・`/groups/:id`・`/users` のルーティングを
-  制御し、`/users/:id` は `UserDetailPage` を直接レンダリングする。各ルートの `element`
-  は空フラグメント（実際の描画は Layout コンポーネントが担う）
+  `/service-unavailable` は認証ガード外に配置。認証が必要なルートは `ProtectedRoute`
+  でラップされ、その内側で `GroupNavigationLayout` が `/`・`/groups`・`/groups/:id`・`/users`
+  のルーティングを制御し、`/users/:id` は `UserDetailPage` を直接レンダリングする。各ルートの
+  `element` は空フラグメント（実際の描画は Layout コンポーネントが担う）
 - `routes/ProtectedRoute.tsx` — 認証ガードコンポーネント。`GET /api/v1/me`
   でセッション確認し、認証済みなら子をレンダリング。未認証・API 障害時は `location.state.reason`
   を付与して `/service-unavailable` へリダイレクト
@@ -89,10 +90,11 @@ FSD の entities レイヤー。現時点では使用していない（ディレ
 FSD の widgets レイヤー。ページ横断で使われる独立した UI ブロックを配置する。
 
 - `header/` — アプリヘッダー（ハンバーガーメニューボタン付き、`z-index: 150`
-  で Sheet オーバーレイより上に固定）。`ui/Header.tsx`、`ui/Header.styles.ts`、テスト。
-  `useAuth()` でログインユーザー情報を取得し、右端の `FaCircleUser` アイコンボタン（`aria-label="Account"`）
-  を押すと Radix UI `DropdownMenu` が開いてユーザーの UUID・氏名を表示する。
-  レイアウトは `gridTemplateColumns: "40px 1fr 40px"` の 3 カラム構成（leading / title / trailing）
+  で Sheet オーバーレイより上に固定）。`ui/Header.tsx`、`ui/Header.styles.ts`、テスト。 `useAuth()`
+  でログインユーザー情報を取得し、右端の `FaCircleUser`
+  アイコンボタン（`aria-label="Account"`）を押すと Radix UI `DropdownMenu`
+  が開いてユーザーの UUID・氏名を表示する。レイアウトは `gridTemplateColumns: "40px 1fr 40px"`
+  の 3 カラム構成（leading / title / trailing）
 - `sidebar/`
   — サイドバーナビゲーション（オーバーレイ付きドロワー）。`ui/Sidebar.tsx`、`ui/Sidebar.styles.ts`、テスト。Props:
   `isOpen`・`onClose`（必須）、`onNavigate`（任意）。"Groups" ボタンをクリックすると `onClose()` と

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -66,12 +66,12 @@ import { apiFetch } from "../../shared/api/client";
 
 ### 認証パターン
 
-`shared/auth` が `AuthContext` を提供し、`AuthProvider` でアプリ全体をラップする（`App.tsx` の
-最上位。`Header` も `useAuth()` を呼び出せるよう、`RouterProvider` より外側に配置されている）。
+`shared/auth` が `AuthContext` を提供し、`AuthProvider` でアプリ全体をラップする（`App.tsx`
+の最上位。`Header` も `useAuth()` を呼び出せるよう、`RouterProvider` より外側に配置されている）。
 
-- `useAuth()` — `{ user, setUser }` を返す。`AuthProvider` 外で呼び出すとエラーをスロー。
-  `Header` ウィジェットも `useAuth()` を呼び出してログインユーザーの UUID・氏名を取得し、
-  `DropdownMenu` で表示する
+- `useAuth()` — `{ user, setUser }` を返す。`AuthProvider` 外で呼び出すとエラーをスロー。 `Header`
+  ウィジェットも `useAuth()` を呼び出してログインユーザーの UUID・氏名を取得し、 `DropdownMenu`
+  で表示する
 - `ProtectedRoute` — マウント時に `GET /api/v1/me` を呼び出してセッション確認。成功時は `setUser`
   でユーザー情報をコンテキストに保存して子をレンダリング。401 は `reason="unauthenticated"` で
   `/service-unavailable` へリダイレクト、その他エラーは `reason="api_unavailable"` でリダイレクト

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -66,10 +66,12 @@ import { apiFetch } from "../../shared/api/client";
 
 ### 認証パターン
 
-`shared/auth` が `AuthContext` を提供し、`AuthProvider` でアプリ全体をラップする（`router.tsx` の
-`Layout` コンポーネント内）。
+`shared/auth` が `AuthContext` を提供し、`AuthProvider` でアプリ全体をラップする（`App.tsx` の
+最上位。`Header` も `useAuth()` を呼び出せるよう、`RouterProvider` より外側に配置されている）。
 
-- `useAuth()` — `{ user, setUser }` を返す。`AuthProvider` 外で呼び出すとエラーをスロー
+- `useAuth()` — `{ user, setUser }` を返す。`AuthProvider` 外で呼び出すとエラーをスロー。
+  `Header` ウィジェットも `useAuth()` を呼び出してログインユーザーの UUID・氏名を取得し、
+  `DropdownMenu` で表示する
 - `ProtectedRoute` — マウント時に `GET /api/v1/me` を呼び出してセッション確認。成功時は `setUser`
   でユーザー情報をコンテキストに保存して子をレンダリング。401 は `reason="unauthenticated"` で
   `/service-unavailable` へリダイレクト、その他エラーは `reason="api_unavailable"` でリダイレクト

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/widgets/sidebar";
 import { RemoveScrollBar } from "react-remove-scroll-bar";
 import { RouterProvider } from "react-router";
 
+import { AuthProvider } from "@/shared/auth";
 import { router } from "./router";
 
 import "./styles/index.css";
@@ -12,17 +13,19 @@ export function App() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   return (
-    <div className="app-shell">
-      {isSidebarOpen && <RemoveScrollBar />}
-      <Header onMenuClick={() => setIsSidebarOpen(true)} />
-      <Sidebar
-        isOpen={isSidebarOpen}
-        onClose={() => setIsSidebarOpen(false)}
-        onNavigate={(path) => router.navigate(path)}
-      />
-      <main className="app-shell__content">
-        <RouterProvider router={router} />
-      </main>
-    </div>
+    <AuthProvider>
+      <div className="app-shell">
+        {isSidebarOpen && <RemoveScrollBar />}
+        <Header onMenuClick={() => setIsSidebarOpen(true)} />
+        <Sidebar
+          isOpen={isSidebarOpen}
+          onClose={() => setIsSidebarOpen(false)}
+          onNavigate={(path) => router.navigate(path)}
+        />
+        <main className="app-shell__content">
+          <RouterProvider router={router} />
+        </main>
+      </div>
+    </AuthProvider>
   );
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -2,18 +2,15 @@ import { createBrowserRouter, Outlet } from "react-router";
 
 import { ServiceUnavailablePage } from "@/pages/service-unavailable";
 import { UserDetailPage } from "@/pages/user-detail";
-import { AuthProvider } from "@/shared/auth";
 import { SheetStackProvider } from "@/shared/lib/sheet-stack";
 import { GroupNavigationLayout } from "./routes/GroupNavigationLayout";
 import { ProtectedRoute } from "./routes/ProtectedRoute";
 
 function Layout() {
   return (
-    <AuthProvider>
-      <SheetStackProvider>
-        <Outlet />
-      </SheetStackProvider>
-    </AuthProvider>
+    <SheetStackProvider>
+      <Outlet />
+    </SheetStackProvider>
   );
 }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,23 @@
 import "@testing-library/jest-dom";
 
+// ResizeObserver mock for jsdom environment
+// jsdom does not implement ResizeObserver natively
+class MockResizeObserver implements ResizeObserver {
+  observe(_target: Element): void {
+    // no-op in tests
+  }
+
+  unobserve(_target: Element): void {
+    // no-op
+  }
+
+  disconnect(): void {
+    // no-op
+  }
+}
+
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
 // IntersectionObserver mock for jsdom environment
 // jsdom does not implement IntersectionObserver natively
 class MockIntersectionObserver implements IntersectionObserver {

--- a/src/widgets/header/ui/Header.styles.ts
+++ b/src/widgets/header/ui/Header.styles.ts
@@ -5,8 +5,7 @@ const colors = {
   border: appColors.separator,
   shadow: "0 16px 32px rgba(15, 23, 42, 0.06)",
   title: appColors.textPrimary,
-  avatarBackground: appColors.accentSoft,
-  avatarText: appColors.accent,
+  avatarText: appColors.textSecondary,
 } as const;
 
 export const styles = {
@@ -60,20 +59,34 @@ export const styles = {
     alignItems: "center",
     justifyContent: "center",
   },
-  accountAvatar: {
-    width: 32,
-    height: 32,
-    borderRadius: 999,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    background: colors.avatarBackground,
+  accountButton: {
     color: colors.avatarText,
-    boxShadow: "inset 0 0 0 1px rgba(0, 122, 255, 0.08)",
   },
-  accountInitials: {
-    fontSize: 12,
-    fontWeight: 700,
-    letterSpacing: -0.1,
+  accountIcon: {
+    width: 24,
+    height: 24,
+    display: "block",
+  },
+  dropdownContent: {
+    minWidth: 220,
+  },
+  dropdownItem: {
+    padding: "8px 12px",
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 2,
+  },
+  dropdownUuid: {
+    fontSize: 11,
+    color: colors.title,
+    letterSpacing: 0,
+    wordBreak: "break-all" as const,
+    margin: 0,
+  },
+  dropdownName: {
+    fontSize: 13,
+    fontWeight: 600,
+    color: colors.title,
+    margin: 0,
   },
 } as const;

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,6 +1,7 @@
-import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
-import { FaBars } from "react-icons/fa6";
+import { Box, DropdownMenu, Flex, IconButton, Text } from "@radix-ui/themes";
+import { FaBars, FaCircleUser } from "react-icons/fa6";
 
+import { useAuth } from "@/shared/auth";
 import { styles } from "./Header.styles";
 
 interface HeaderProps {
@@ -8,6 +9,8 @@ interface HeaderProps {
 }
 
 export function Header({ onMenuClick }: HeaderProps) {
+  const { user } = useAuth();
+
   return (
     <Box asChild>
       <header style={styles.header}>
@@ -28,11 +31,34 @@ export function Header({ onMenuClick }: HeaderProps) {
             Sample Front
           </Text>
           <Flex style={styles.trailing}>
-            <Box style={styles.accountAvatar} role="img" aria-label="Account">
-              <Text as="span" style={styles.accountInitials}>
-                HR
-              </Text>
-            </Box>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger>
+                <IconButton
+                  size="2"
+                  variant="ghost"
+                  radius="full"
+                  style={styles.accountButton}
+                  aria-label="Account"
+                >
+                  <FaCircleUser aria-hidden="true" style={styles.accountIcon} />
+                </IconButton>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content
+                style={styles.dropdownContent}
+                align="end"
+                side="bottom"
+                onCloseAutoFocus={(e) => e.preventDefault()}
+              >
+                <Box style={styles.dropdownItem}>
+                  <Text as="p" style={styles.dropdownUuid}>
+                    {user?.uuid}
+                  </Text>
+                  <Text as="p" style={styles.dropdownName}>
+                    {user?.firstName} {user?.lastName}
+                  </Text>
+                </Box>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
           </Flex>
         </Flex>
       </header>

--- a/src/widgets/header/ui/__tests__/Header.test.tsx
+++ b/src/widgets/header/ui/__tests__/Header.test.tsx
@@ -1,37 +1,118 @@
 import { Header } from "@/widgets/header";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "@/shared/auth";
+
+vi.mock("@/shared/auth", () => ({
+  useAuth: vi.fn(() => ({
+    user: {
+      id: 1,
+      uuid: "test-uuid-xxxx",
+      firstName: "太郎",
+      lastName: "山田",
+    },
+    setUser: vi.fn(),
+  })),
+}));
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<Theme>{ui}</Theme>);
+}
 
 describe("Header", () => {
   it("画面タイトルを表示する", () => {
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     expect(screen.getByText("Sample Front")).toBeInTheDocument();
   });
 
   it("アカウント表示を表示する", () => {
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     expect(screen.getByLabelText("Account")).toBeInTheDocument();
   });
 
   it("ハンバーガーメニューを表示する", () => {
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     expect(screen.getByLabelText("Open navigation")).toBeInTheDocument();
   });
 
   it("banner ロールを持つ", () => {
-    render(<Header />);
+    renderWithTheme(<Header />);
 
     expect(screen.getByRole("banner")).toBeInTheDocument();
   });
 
-  it("メニューボタンをクリックすると onMenuClick が呼ばれる", () => {
+  it("メニューボタンをクリックすると onMenuClick が呼ばれる", async () => {
     const onMenuClick = vi.fn();
-    render(<Header onMenuClick={onMenuClick} />);
+    renderWithTheme(<Header onMenuClick={onMenuClick} />);
 
-    fireEvent.click(screen.getByLabelText("Open navigation"));
+    await userEvent.click(screen.getByLabelText("Open navigation"));
     expect(onMenuClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("FaCircleUser アイコンが描画される — aria-label=Account のボタンが存在する", () => {
+    renderWithTheme(<Header />);
+
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    expect(accountButton).toBeInTheDocument();
+  });
+
+  it("アイコンクリックでドロップダウンが開く — UUID とユーザー名が DOM に表示される", async () => {
+    renderWithTheme(<Header />);
+
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    await userEvent.click(accountButton);
+
+    expect(screen.getByText("test-uuid-xxxx")).toBeInTheDocument();
+    expect(screen.getByText("太郎 山田")).toBeInTheDocument();
+  });
+
+  it("ドロップダウン内に UUID が表示される", async () => {
+    renderWithTheme(<Header />);
+
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    await userEvent.click(accountButton);
+
+    expect(screen.getByText("test-uuid-xxxx")).toBeInTheDocument();
+  });
+
+  it("ドロップダウン内にユーザー名が表示される", async () => {
+    renderWithTheme(<Header />);
+
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    await userEvent.click(accountButton);
+
+    expect(screen.getByText("太郎 山田")).toBeInTheDocument();
+  });
+
+  it("HR テキストが DOM に存在しない", () => {
+    renderWithTheme(<Header />);
+
+    expect(screen.queryByText("HR")).not.toBeInTheDocument();
+  });
+
+  it("useAuth モックで UUID とユーザー名を差し替えられる", async () => {
+    vi.mocked(useAuth).mockReturnValueOnce({
+      user: {
+        id: 2,
+        uuid: "another-uuid-yyyy",
+        firstName: "花子",
+        lastName: "鈴木",
+      },
+      setUser: vi.fn(),
+    });
+
+    renderWithTheme(<Header />);
+
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    await userEvent.click(accountButton);
+
+    expect(screen.getByText("another-uuid-yyyy")).toBeInTheDocument();
+    expect(screen.getByText("花子 鈴木")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 変更内容

- Header コンポーネントに Radix UI `DropdownMenu` を追加し、ログインユーザーの UUID・氏名を表示
- `FaCircleUser` アイコンボタン（`aria-label="Account"`）をトリガーに変更
- `AuthProvider` を `router.tsx` の `Layout` から `App.tsx` 最上位に移動（`Header` が `useAuth()` を参照できるよう配置変更）
- `src/test/setup.ts` に `ResizeObserver` モックを追加
- Header テストに DropdownMenu 関連のケースを追加（Theme ラッパー + userEvent 使用）

## 関連

spec-to-dev-workflow の実装による変更