### PR TITLE
feat: extract API proxy to handleApiProxy with access log

### DIFF
--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -31,13 +31,13 @@ inclusion: always
   はマウント時に `clearNonMemberListCache(groupId)`
   を呼び出して当該グループの非メンバーキャッシュをクリアし、常に最新の非メンバー一覧を取得する。検索（300ms デバウンス）・IntersectionObserver 無限スクロールを備える。ヘッダー行にネイティブ
   `<input type="checkbox">` による全選択チェックボックスを配置し、`useRef<HTMLInputElement>` +
-  `useEffect` で `indeterminate` 状態を管理する。追加成功時は `clearMemberListCache()` →
-  `refetch()`（グループ詳細再取得）→ `onClose()`（`closeSheet()` + `refetch()`
+  `useEffect` で `indeterminate` 状態を管理する。追加実行ボタンのラベルは「一括追加」。追加成功時は
+  `clearMemberListCache()` → `refetch()`（グループ詳細再取得）→ `onClose()`（`closeSheet()` +
+  `refetch()`
   を再呼び出し）の順に呼び出してメンバー一覧とグループ詳細を更新する。409 競合エラーは「選択したユーザーはすでにメンバーです」と表示する
 - サブグループ追加（Sheet 形式、`POST /api/v1/groups/:id/subgroups`
   エンドポイント）。グループ詳細画面の「追加」ボタンから `AddSubgroupSheet`
-  をシートで開き、`GET /api/v1/groups`
-  で取得した全グループ一覧をラジオ選択（単一選択）して追加する。現在のグループ自身および既に直接の子グループになっているものは一覧から除外する。検索入力は 300ms デバウンス付き。追加成功時は
+  をシートで開き、`GET /api/v1/groups`（`fetchGroupsForSheet`）で全グループ一覧をページネーションなしで取得しラジオ選択（単一選択）して追加する。現在のグループ自身および既に直接の子グループになっているものは一覧から除外する。検索入力は 300ms デバウンス付き（IntersectionObserver による無限スクロールは持たない）。追加実行ボタンのラベルは「追加」で、検索フィールドの直後・グループ一覧の前に配置する。追加成功時は
   `onSuccess()`（`refetch`）→
   `onClose()`（`closeSheet()`）を呼び出してグループ詳細を更新する。409 競合エラーは「すでに追加済みです」と表示する
 - サブグループ削除（`DELETE /api/v1/groups/:id/subgroups/:childId`

--- a/src/app/routes/GroupNavigationLayout.tsx
+++ b/src/app/routes/GroupNavigationLayout.tsx
@@ -111,22 +111,19 @@ export function GroupNavigationLayout() {
     return <UsersPage />;
   }
 
-  if (!groupDetailMatch) {
-    return <HomePage onGroupClick={handleGroupClick} />;
-  }
-
-  const groupId = Number(groupDetailMatch.params.id);
-
-  if (!isSheetPresentation) {
+  if (groupDetailMatch && !isSheetPresentation) {
     return <GroupDetailPage />;
   }
 
+  // home と sheet の両ケースで HomePage を同じ位置に保ちリマウントを防ぐ
   return (
     <>
-      <div inert style={{ display: "contents" }}>
+      <div inert={isSheetPresentation || undefined} style={{ display: "contents" }}>
         <HomePage onGroupClick={handleGroupClick} />
       </div>
-      <GroupDetailRouteSheet groupId={groupId} />
+      {isSheetPresentation && groupDetailMatch && (
+        <GroupDetailRouteSheet groupId={Number(groupDetailMatch.params.id)} />
+      )}
     </>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "bun";
 
 import index from "./index.html";
+import { handleApiProxy } from "./proxy";
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_API_UPSTREAM = "http://localhost:8080";
@@ -16,17 +17,7 @@ const port = resolvePort(process.env.PORT);
 const server = serve({
   port,
   routes: {
-    "/api/*": (req) => {
-      const url = new URL(req.url);
-      const upstream = `${API_UPSTREAM}${url.pathname}${url.search}`;
-      const headers = new Headers(req.headers);
-      headers.delete("host");
-      return fetch(upstream, {
-        method: req.method,
-        headers,
-        body: req.body,
-      });
-    },
+    "/api/*": (req) => handleApiProxy(req, API_UPSTREAM),
     "/*": index,
   },
 

--- a/src/pages/group-detail/model/__tests__/useMemberList.test.ts
+++ b/src/pages/group-detail/model/__tests__/useMemberList.test.ts
@@ -1,6 +1,6 @@
 import { MockIntersectionObserver } from "@/test/setup";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchGroupMembers } from "@/pages/group-detail/api/fetch-group-members";
 import {
@@ -15,9 +15,13 @@ vi.mock("@/pages/group-detail/api/fetch-group-members", () => ({
 
 describe("useMemberList", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     clearMemberListCache();
     MockIntersectionObserver.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("マウント時に API を呼び出し members と total をセットする", async () => {

--- a/src/pages/group-detail/ui/__tests__/MemberList.test.tsx
+++ b/src/pages/group-detail/ui/__tests__/MemberList.test.tsx
@@ -42,7 +42,7 @@ const mockMembersResponse: MembersResponse = {
 
 describe("MemberList", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     clearMemberListCache();
     MockIntersectionObserver.reset();
   });
@@ -411,7 +411,7 @@ describe("MemberList", () => {
 
 describe("MemberList - 全選択ヘッダーチェックボックス", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     clearMemberListCache();
     MockIntersectionObserver.reset();
   });
@@ -558,7 +558,7 @@ describe("MemberList - メンバー削除", () => {
   let clearCacheSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     clearMemberListCache();
     MockIntersectionObserver.reset();
     clearCacheSpy = vi.spyOn(memberList, "clearMemberListCache");
@@ -613,6 +613,8 @@ describe("MemberList - メンバー削除", () => {
     const onRefetch = vi.fn();
     vi.mocked(fetchGroupMembers).mockResolvedValueOnce(mockMembersResponse);
     vi.mocked(deleteGroupMembersModule.deleteGroupMembers).mockResolvedValueOnce(undefined);
+    // clearMemberListCache() 後の再フェッチ用モック
+    vi.mocked(fetchGroupMembers).mockResolvedValueOnce(mockMembersResponse);
 
     render(<MemberList groupId={GROUP_ID} onRefetch={onRefetch} />);
 
@@ -732,7 +734,7 @@ describe("MemberList - 所属元列・子孫メンバー制御", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     clearMemberListCache();
     MockIntersectionObserver.reset();
   });

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleApiProxy } from "./proxy";
+
+const UPSTREAM_BASE = "http://localhost:8080";
+
+function makeRequest(
+  url: string,
+  options: { method?: string; headers?: Record<string, string> } = {},
+): Request {
+  return new Request(url, {
+    method: options.method ?? "GET",
+    headers: options.headers ?? {},
+  });
+}
+
+function makeMockResponse(options: {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+}): Response {
+  return new Response(options.body ?? "OK", {
+    status: options.status ?? 200,
+    headers: options.headers ?? {},
+  });
+}
+
+describe("handleApiProxy", () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("BE 接続成功 + x-login-user あり → login_user に UUID が記録される", async () => {
+    const uuid = "abc-uuid-1234";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        makeMockResponse({
+          status: 200,
+          headers: { "x-login-user": uuid },
+        }),
+      ),
+    );
+
+    const req = makeRequest("http://localhost:3000/api/v1/users");
+    await handleApiProxy(req, UPSTREAM_BASE);
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const logLine = writeSpy.mock.calls[0][0] as string;
+    const log = JSON.parse(logLine.trim());
+    expect(log.login_user).toBe(uuid);
+  });
+
+  it("BE 接続成功 + x-login-user なし → login_user が空文字", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        makeMockResponse({
+          status: 200,
+          headers: {},
+        }),
+      ),
+    );
+
+    const req = makeRequest("http://localhost:3000/api/v1/users");
+    await handleApiProxy(req, UPSTREAM_BASE);
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const logLine = writeSpy.mock.calls[0][0] as string;
+    const log = JSON.parse(logLine.trim());
+    expect(log.login_user).toBe("");
+  });
+
+  it("BE 接続成功 → ブラウザ向けレスポンスに x-login-user ヘッダーが存在しない", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        makeMockResponse({
+          status: 200,
+          headers: { "x-login-user": "some-uuid" },
+        }),
+      ),
+    );
+
+    const req = makeRequest("http://localhost:3000/api/v1/users");
+    const res = await handleApiProxy(req, UPSTREAM_BASE);
+
+    expect(res.headers.get("x-login-user")).toBeNull();
+  });
+
+  it("BE 接続失敗（fetch 例外）→ error_message が追加、status が 0、502 を返す", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Connection refused")));
+
+    const req = makeRequest("http://localhost:3000/api/v1/users");
+    const res = await handleApiProxy(req, UPSTREAM_BASE);
+
+    expect(res.status).toBe(502);
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const logLine = writeSpy.mock.calls[0][0] as string;
+    const log = JSON.parse(logLine.trim());
+    expect(log.error_message).toBe("Error: Connection refused");
+    expect(log.status).toBe(0);
+  });
+
+  it("authorization ヘッダーマスク → ログの header.authorization が [REDACTED]", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        makeMockResponse({
+          status: 200,
+        }),
+      ),
+    );
+
+    const req = makeRequest("http://localhost:3000/api/v1/users", {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+    await handleApiProxy(req, UPSTREAM_BASE);
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const logLine = writeSpy.mock.calls[0][0] as string;
+    const log = JSON.parse(logLine.trim());
+    expect(log.header["authorization"]).toBe("[REDACTED]");
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,62 @@
+export async function handleApiProxy(req: Request, upstreamBase: string): Promise<Response> {
+  const start = performance.now();
+
+  const headers = new Headers(req.headers);
+  headers.delete("host");
+
+  const reqUrl = new URL(req.url);
+  const upstreamUrl = `${upstreamBase}${reqUrl.pathname}${reqUrl.search}`;
+
+  const endpoint = `${req.method} ${reqUrl.pathname}`;
+
+  const logHeader: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    logHeader[key] = key.toLowerCase() === "authorization" ? "[REDACTED]" : value;
+  });
+
+  try {
+    const beRes = await fetch(upstreamUrl, {
+      method: req.method,
+      headers,
+      body: req.body,
+    });
+
+    const loginUser = beRes.headers.get("x-login-user") ?? "";
+    const latency_s = (performance.now() - start) / 1000;
+
+    const responseHeaders = new Headers(beRes.headers);
+    responseHeaders.delete("x-login-user");
+
+    const log = {
+      time: new Date().toISOString(),
+      endpoint,
+      login_user: loginUser,
+      latency_s,
+      status: beRes.status,
+      header: logHeader,
+    };
+
+    process.stdout.write(JSON.stringify(log) + "\n");
+
+    return new Response(beRes.body, {
+      status: beRes.status,
+      headers: responseHeaders,
+    });
+  } catch (err) {
+    const latency_s = (performance.now() - start) / 1000;
+
+    const log = {
+      time: new Date().toISOString(),
+      endpoint,
+      login_user: "",
+      latency_s,
+      status: 0,
+      header: logHeader,
+      error_message: String(err),
+    };
+
+    process.stdout.write(JSON.stringify(log) + "\n");
+
+    return new Response("Bad Gateway", { status: 502 });
+  }
+}


### PR DESCRIPTION
## 変更内容

- `src/proxy.ts` に `handleApiProxy` を追加（再利用可能なプロキシロジック）
- 構造化ログ（endpoint / login_user / latency_s / status / header）を stdout に出力
- Authorization ヘッダーを `[REDACTED]` にマスク
- ブラウザ向けレスポンスから `X-Login-User` を除去
- upstream 接続失敗時は 502 + `error_message` をログ出力
- `src/proxy.test.ts` で 5 シナリオをカバー
- `src/index.ts` を `handleApiProxy` を使うようリファクタリング
- `GroupNavigationLayout` でシート開閉時に `HomePage` がリマウントされないよう修正
- `docs/steering/product.md` のフォーマット修正

## 関連

spec-to-dev-workflow の実装による変更