### PR TITLE
feat: add useSubgroups hook and fetch-subgroups for SubgroupManagementSheet

### DIFF
--- a/src/pages/group-detail/api/__tests__/fetch-subgroups.test.ts
+++ b/src/pages/group-detail/api/__tests__/fetch-subgroups.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchSubgroups } from "@/pages/group-detail/api/fetch-subgroups";
+
+vi.mock("@/shared/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+describe("fetchSubgroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常系: 200 を受け取り subgroups 配列を返す", async () => {
+    const { apiFetch } = await import("@/shared/api");
+    const mockSubgroups = [
+      { id: 2, name: "Frontend Team", description: "FE チーム", member_count: 3 },
+      { id: 3, name: "Backend Team", description: "BE チーム", member_count: 4 },
+    ];
+    vi.mocked(apiFetch).mockResolvedValueOnce({ subgroups: mockSubgroups });
+
+    const result = await fetchSubgroups(1);
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/groups/1/subgroups");
+    expect(result).toEqual(mockSubgroups);
+  });
+
+  it("境界値: 0 件レスポンスで空配列を返す", async () => {
+    const { apiFetch } = await import("@/shared/api");
+    vi.mocked(apiFetch).mockResolvedValueOnce({ subgroups: [] });
+
+    const result = await fetchSubgroups(999);
+
+    expect(result).toEqual([]);
+  });
+
+  it("異常系: エラーレスポンスで throw する", async () => {
+    const { apiFetch } = await import("@/shared/api");
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error("500 Internal Server Error"));
+
+    await expect(fetchSubgroups(1)).rejects.toThrow("500 Internal Server Error");
+  });
+});

--- a/src/pages/group-detail/api/fetch-subgroups.ts
+++ b/src/pages/group-detail/api/fetch-subgroups.ts
@@ -1,0 +1,13 @@
+import type { SubgroupSummary } from "@/entities/group";
+
+import { apiFetch } from "@/shared/api";
+
+type SubgroupsResponse = {
+  subgroups: SubgroupSummary[];
+};
+
+export function fetchSubgroups(groupId: number): Promise<SubgroupSummary[]> {
+  return apiFetch<SubgroupsResponse>(`/api/v1/groups/${String(groupId)}/subgroups`).then(
+    (res) => res.subgroups,
+  );
+}

--- a/src/pages/group-detail/model/__tests__/useSubgroups.test.ts
+++ b/src/pages/group-detail/model/__tests__/useSubgroups.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchSubgroups } from "@/pages/group-detail/api/fetch-subgroups";
+import { useSubgroups } from "@/pages/group-detail/model/useSubgroups";
+
+vi.mock("@/pages/group-detail/api/fetch-subgroups", () => ({
+  fetchSubgroups: vi.fn(),
+}));
+
+const sampleSubgroups = [
+  { id: 2, name: "Frontend Team", description: "FE チーム", member_count: 3 },
+  { id: 3, name: "Backend Team", description: "BE チーム", member_count: 4 },
+];
+
+describe("useSubgroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("状態変化: 初回マウントで取得し subgroups を反映、refetch を呼ぶと再取得される", async () => {
+    vi.mocked(fetchSubgroups).mockResolvedValue(sampleSubgroups);
+
+    const { result } = renderHook(() => useSubgroups(1));
+
+    await waitFor(() => {
+      expect(result.current.subgroups).toEqual(sampleSubgroups);
+    });
+
+    expect(fetchSubgroups).toHaveBeenCalledTimes(1);
+    expect(fetchSubgroups).toHaveBeenCalledWith(1);
+
+    // refetch を呼ぶと再取得される
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(fetchSubgroups).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.subgroups).toEqual(sampleSubgroups);
+  });
+
+  it("異常系: 取得失敗時は state が空のまま、コンソールエラーが出る", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(fetchSubgroups).mockRejectedValueOnce(new Error("fetch failed"));
+
+    const { result } = renderHook(() => useSubgroups(1));
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    expect(result.current.subgroups).toEqual([]);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/pages/group-detail/model/useSubgroups.ts
+++ b/src/pages/group-detail/model/useSubgroups.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+import type { SubgroupSummary } from "@/entities/group";
+
+import { fetchSubgroups } from "@/pages/group-detail/api/fetch-subgroups";
+
+export function useSubgroups(groupId: number): {
+  subgroups: SubgroupSummary[];
+  refetch: () => void;
+} {
+  const [subgroups, setSubgroups] = useState<SubgroupSummary[]>([]);
+  const [refetchKey, setRefetchKey] = useState(0);
+
+  const refetch = useCallback(() => {
+    setRefetchKey((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchSubgroups(groupId)
+      .then((data) => {
+        if (!isActive) return;
+        setSubgroups(data);
+      })
+      .catch((err: unknown) => {
+        if (!isActive) return;
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [groupId, refetchKey]);
+
+  return { subgroups, refetch };
+}

--- a/src/pages/group-detail/ui/SubgroupManagementSheet.tsx
+++ b/src/pages/group-detail/ui/SubgroupManagementSheet.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { Box, Button, Flex, Text } from "@radix-ui/themes";
 
-import { useGroupDetail } from "@/pages/group-detail/model/useGroupDetail";
+import { useSubgroups } from "@/pages/group-detail/model/useSubgroups";
 import { appColors } from "@/shared/config";
 import { useSheetStack } from "@/shared/lib/sheet-stack";
 import { AddSubgroupSheet } from "./AddSubgroupSheet";
@@ -73,7 +73,7 @@ type SubgroupManagementSheetProps = {
 
 export function SubgroupManagementSheet({ groupId, groupName }: SubgroupManagementSheetProps) {
   const { openSheet } = useSheetStack();
-  const { subgroups, refetch } = useGroupDetail(groupId);
+  const { subgroups, refetch } = useSubgroups(groupId);
   const [deletingSubgroupId, setDeletingSubgroupId] = useState<number | null>(null);
 
   const handleAddClick = useCallback(() => {

--- a/src/pages/group-detail/ui/__tests__/SubgroupManagementSheet.test.tsx
+++ b/src/pages/group-detail/ui/__tests__/SubgroupManagementSheet.test.tsx
@@ -27,8 +27,8 @@ vi.mock("@/pages/group-detail/ui/AddSubgroupSheet", () => ({
   AddSubgroupSheet: mockAddSubgroupSheet,
 }));
 
-vi.mock("@/pages/group-detail/model/useGroupDetail", () => ({
-  useGroupDetail: vi.fn(),
+vi.mock("@/pages/group-detail/model/useSubgroups", () => ({
+  useSubgroups: vi.fn(),
 }));
 
 const mockDeleteSubgroup = deleteSubgroup as ReturnType<typeof vi.fn>;
@@ -50,11 +50,8 @@ describe("SubgroupManagementSheet", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    const { useGroupDetail } = await import("@/pages/group-detail/model/useGroupDetail");
-    vi.mocked(useGroupDetail).mockReturnValue({
-      group: null,
-      error: null,
-      isLoading: false,
+    const { useSubgroups } = await import("@/pages/group-detail/model/useSubgroups");
+    vi.mocked(useSubgroups).mockReturnValue({
       refetch: vi.fn(),
       subgroups: sampleSubgroups,
     });
@@ -88,11 +85,8 @@ describe("SubgroupManagementSheet", () => {
   });
 
   it("サブグループが空の場合に空状態メッセージが表示される", async () => {
-    const { useGroupDetail } = await import("@/pages/group-detail/model/useGroupDetail");
-    vi.mocked(useGroupDetail).mockReturnValue({
-      group: null,
-      error: null,
-      isLoading: false,
+    const { useSubgroups } = await import("@/pages/group-detail/model/useSubgroups");
+    vi.mocked(useSubgroups).mockReturnValue({
       refetch: vi.fn(),
       subgroups: [],
     });
@@ -120,12 +114,9 @@ describe("SubgroupManagementSheet", () => {
     const user = userEvent.setup();
     mockDeleteSubgroup.mockResolvedValueOnce(undefined);
 
-    const { useGroupDetail } = await import("@/pages/group-detail/model/useGroupDetail");
+    const { useSubgroups } = await import("@/pages/group-detail/model/useSubgroups");
     const mockRefetch = vi.fn();
-    vi.mocked(useGroupDetail).mockReturnValue({
-      group: null,
-      error: null,
-      isLoading: false,
+    vi.mocked(useSubgroups).mockReturnValue({
       refetch: mockRefetch,
       subgroups: sampleSubgroups,
     });
@@ -173,15 +164,38 @@ describe("SubgroupManagementSheet", () => {
     );
   });
 
+  it("AddSubgroupSheet に useSubgroups の subgroups を props で渡す", async () => {
+    const user = userEvent.setup();
+
+    const { useSheetStack } = await import("@/shared/lib/sheet-stack");
+    const mockOpenSheet = vi.fn();
+    vi.mocked(useSheetStack).mockReturnValue({
+      openSheet: mockOpenSheet,
+      closeSheet: vi.fn(),
+      sheets: [],
+      removeSheet: vi.fn(),
+      closeAll: vi.fn(),
+    });
+
+    renderSheet();
+
+    await user.click(screen.getByRole("button", { name: "＋ 追加" }));
+
+    expect(mockOpenSheet).toHaveBeenCalledOnce();
+
+    const openSheetArg = mockOpenSheet.mock.calls[0]?.[0] as {
+      id: string;
+      content: { props: { subgroups: SubgroupSummary[] } };
+    };
+    expect(openSheetArg.content.props.subgroups).toEqual(sampleSubgroups);
+  });
+
   it("「＋ 追加」ボタンクリックで AddSubgroupSheet の onClose コールバック経由で refetch が呼ばれる", async () => {
     const user = userEvent.setup();
 
-    const { useGroupDetail } = await import("@/pages/group-detail/model/useGroupDetail");
+    const { useSubgroups } = await import("@/pages/group-detail/model/useSubgroups");
     const mockRefetch = vi.fn();
-    vi.mocked(useGroupDetail).mockReturnValue({
-      group: null,
-      error: null,
-      isLoading: false,
+    vi.mocked(useSubgroups).mockReturnValue({
       refetch: mockRefetch,
       subgroups: sampleSubgroups,
     });


### PR DESCRIPTION
## 変更内容

SubgroupManagementSheet が `useGroupDetail` 経由でグループ詳細全体を取り直していたのを、サブグループ一覧専用の `useSubgroups` フックに差し替えた。他の group-detail 画面は無変更で `useGroupDetail` を継続利用する。

- 新規 `pages/group-detail/api/fetch-subgroups.ts`（`apiFetch` で GET /api/v1/groups/:id/subgroups）
- 新規 `pages/group-detail/model/useSubgroups.ts`（`useGroupDetail` と同パターン: `useEffect` + `useState` + `refetchKey`、エラー時は console.error のみ）
- `SubgroupManagementSheet.tsx` を `useSubgroups` に切り替え、`AddSubgroupSheet` には引き続き props で subgroups を渡す
- テスト追加・更新（fetch-subgroups 3 件 / useSubgroups 2 件 / SubgroupManagementSheet の mock 差し替え + `AddSubgroupSheet` への props 検証）

## 関連
spec-to-dev-workflow の実装による変更